### PR TITLE
Fix Paper 1.21.11 compatibility and TemporaryPlayer issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.kteq</groupId>
     <artifactId>hiddenarmor</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1</version>
     <packaging>jar</packaging>
 
     <name>HiddenArmor</name>
@@ -47,7 +47,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.3.1</version>
                 <executions>
                     <execution>
                         <id>copy-files-on-build</id>
@@ -98,10 +98,6 @@
 
     <repositories>
         <repository>
-            <id>spigotmc-repo</id>
-            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
-        </repository>
-        <repository>
             <id>sonatype</id>
             <url>https://oss.sonatype.org/content/groups/public/</url>
         </repository>
@@ -109,19 +105,23 @@
             <id>dmulloy2-repo</id>
             <url>https://repo.dmulloy2.net/repository/public/</url>
         </repository>
+        <repository>
+            <id>papermc</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
+        </repository>
     </repositories>
 
     <dependencies>
         <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot-api</artifactId>
-            <version>1.16.5-R0.1-SNAPSHOT</version>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>1.21.11-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.comphenix.protocol</groupId>
+            <groupId>net.dmulloy2</groupId>
             <artifactId>ProtocolLib</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/me/kteq/hiddenarmor/handler/ArmorPlaceholderHandler.java
+++ b/src/main/java/me/kteq/hiddenarmor/handler/ArmorPlaceholderHandler.java
@@ -5,7 +5,6 @@ import me.kteq.hiddenarmor.HiddenArmor;
 import me.kteq.hiddenarmor.util.ConfigHolder;
 import me.kteq.hiddenarmor.util.ItemUtil;
 import me.kteq.hiddenarmor.util.StrUtil;
-import org.apache.commons.lang.WordUtils;
 import org.bukkit.Material;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeModifier;
@@ -111,7 +110,7 @@ public class ArmorPlaceholderHandler implements ConfigHolder {
     private String buildName(ItemStack itemStack){
         String name = itemStack.getType().toString();
         name = name.replaceAll("_", " ");
-        name = WordUtils.capitalizeFully(name);
+        name = capitalizeFully(name);
 
         ItemMeta itemMeta = itemStack.getItemMeta();
         if(itemMeta != null && itemMeta.hasDisplayName())
@@ -119,6 +118,27 @@ public class ArmorPlaceholderHandler implements ConfigHolder {
         else
             name = StrUtil.color("&r") + name;
         return name;
+    }
+
+    private String capitalizeFully(String str) {
+        if (str == null || str.isEmpty()) {
+            return str;
+        }
+        String[] words = str.split(" ");
+        StringBuilder result = new StringBuilder();
+        for (int i = 0; i < words.length; i++) {
+            if (i > 0) {
+                result.append(" ");
+            }
+            String word = words[i];
+            if (!word.isEmpty()) {
+                result.append(Character.toUpperCase(word.charAt(0)));
+                if (word.length() > 1) {
+                    result.append(word.substring(1).toLowerCase());
+                }
+            }
+        }
+        return result.toString();
     }
 
     @Override

--- a/src/main/java/me/kteq/hiddenarmor/manager/PlayerManager.java
+++ b/src/main/java/me/kteq/hiddenarmor/manager/PlayerManager.java
@@ -76,24 +76,36 @@ public class PlayerManager implements ConfigHolder {
     }
 
     public boolean isEnabled(Player player) {
-        return this.enabledPlayersUUID.contains(player.getUniqueId());
+        try {
+            if (player == null) return false;
+            return this.enabledPlayersUUID.contains(player.getUniqueId());
+        } catch (UnsupportedOperationException e) {
+            // TemporaryPlayer during connection, armor should be visible by default
+            return false;
+        }
     }
 
     public boolean isArmorVisible(Player player) {
-        boolean hidden = isEnabled(player);
-        for (Predicate<Player> predicate : forceDisablePredicates) {
-            if (predicate.test(player)) {
-                hidden = false;
-                break;
+        try {
+            if (player == null) return true;
+            boolean hidden = isEnabled(player);
+            for (Predicate<Player> predicate : forceDisablePredicates) {
+                if (predicate.test(player)) {
+                    hidden = false;
+                    break;
+                }
             }
-        }
-        for (Predicate<Player> predicate : forceEnablePredicates) {
-            if (predicate.test(player)) {
-                hidden = true;
-                break;
+            for (Predicate<Player> predicate : forceEnablePredicates) {
+                if (predicate.test(player)) {
+                    hidden = true;
+                    break;
+                }
             }
+            return !hidden;
+        } catch (UnsupportedOperationException e) {
+            // TemporaryPlayer during connection, armor should be visible by default
+            return true;
         }
-        return !hidden;
     }
 
     private void registerDefaultPredicates() {


### PR DESCRIPTION
- Update Paper API to 1.21.11-R0.1-SNAPSHOT
- Update ProtocolLib to 5.4.0
- Fix UnsupportedOperationException for TemporaryPlayer objects
- Replace Apache Commons Lang WordUtils with custom implementation
- Add proper error handling for packet listeners
- Improve null-safety in PlayerManager methods

Fixes compatibility issues with Paper 1.21.10 server startup